### PR TITLE
Update Flatpak runtime from EOL KDE 6.6 to KDE 6.9

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -9,7 +9,7 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:kde-6.6
+      image: bilelmoussaoui/flatpak-github-actions:kde-6.9
       options: --privileged
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ cmake --install build
 ### Install Runtime
 ```shell
 flatpak install \
-    runtime/org.kde.Platform/x86_64/6.6\
-    runtime/org.kde.Sdk/x86_64/6.6\
-    runtime/org.freedesktop.Sdk.Extension.openjdk21/x86_64/23.08
+    runtime/org.kde.Platform/x86_64/6.9\
+    runtime/org.kde.Sdk/x86_64/6.9\
+    runtime/org.freedesktop.Sdk.Extension.openjdk21/x86_64/25.08
 ```
 
 ### Build

--- a/io.github.glaumar.QRookie.yml
+++ b/io.github.glaumar.QRookie.yml
@@ -1,6 +1,6 @@
 app-id: io.github.glaumar.QRookie
 runtime: org.kde.Platform
-runtime-version: "6.6"
+runtime-version: "6.9"
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk21


### PR DESCRIPTION
Motivation
  flatpak update reports the current runtime stack as end-of-life:

  > Info: runtime org.kde.Platform branch 6.6 is end-of-life, with reason:
  > We strongly recommend moving to the latest stable version of the Platform and SDK
  > Info: applications using this runtime:
  > io.github.glaumar.QRookie
  >
  > Info: runtime org.freedesktop.Platform.GL.default branch 23.08-extra is end-of-life, with reason:
  > org.freedesktop.Platform 23.08 is no longer receiving fixes and security updates. Please update to a supported runtime version.
  > Info: applications using this extension:
  > io.github.glaumar.QRookie
  >
  > Info: runtime org.freedesktop.Platform.GL.default branch 23.08 is end-of-life, with reason:
  > org.freedesktop.Platform 23.08 is no longer receiving fixes and security updates. Please update to a supported runtime version.
  > Info: applications using this extension:
  > io.github.glaumar.QRookie

Validation

  - Local flatpak-builder build completed successfully.
  - App launched successfully from the new Flatpak build.
  - A game was sideloaded and validated on Meta Quest 3.